### PR TITLE
fix: use env var for cargo publish token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Build Rust binaries for multiple platforms
   build:


### PR DESCRIPTION
## Problem
`cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}` fails with:
```
error: a value is required for '--token <TOKEN>' but none was supplied
```
The secret expression expands to empty when passed as a CLI arg.

## Fix
Use the `CARGO_REGISTRY_TOKEN` environment variable instead — `cargo publish` reads it automatically. This is also the [recommended approach](https://doc.rust-lang.org/cargo/reference/config.html#registrytoken) and avoids exposing the token in process arguments.

## After merge
Delete tag v5.1.0 and re-tag to trigger the release workflow:
```sh
git push origin :refs/tags/v5.1.0
git tag -d v5.1.0
git checkout main && git pull
git tag v5.1.0 -m "Release v5.1.0"
git push origin v5.1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline configuration.

**Note:** This release contains no user-facing changes or improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->